### PR TITLE
fix: nil pointer error in pod health

### DIFF
--- a/pkg/health/health_pod.go
+++ b/pkg/health/health_pod.go
@@ -234,7 +234,7 @@ func getCorev1PodHealth(pod *corev1.Pod) (*HealthStatus, error) {
 					continue
 				}
 
-				if time.Since(c.Status.State.Running.StartedAt.Time) <= time.Duration(c.Spec.ReadinessProbe.InitialDelaySeconds)*time.Second {
+				if c.Status.State.Running != nil && time.Since(c.Status.State.Running.StartedAt.Time) <= time.Duration(c.Spec.ReadinessProbe.InitialDelaySeconds)*time.Second {
 					containersWaitingForReadinessProbe = append(containersWaitingForReadinessProbe, c.Spec.Name)
 				}
 			}


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x3fdd834]

goroutine 8151530 [running]:
github.com/flanksource/is-healthy/pkg/health.getCorev1PodHealth(0xc00b980008)
	/go/pkg/mod/github.com/flanksource/is-healthy@v1.0.26/pkg/health/health_pod.go:237 +0xf54
github.com/flanksource/is-healthy/pkg/health.getPodHealth(0xc00764ce58)
	/go/pkg/mod/github.com/flanksource/is-healthy@v1.0.26/pkg/health/health_pod.go:23 +0x1c8
github.com/flanksource/is-healthy/pkg/health.GetResourceHealth(0xc00764ce58, {0xa97bae0, 0xc027a97f50})
	/go/pkg/mod/github.com/flanksource/is-healthy@v1.0.26/pkg/health/health.go:112 +0xe2
github.com/flanksource/config-db/scrapers/kubernetes.ExtractResults(0xc00cdcc808, {0xc001116008, 0x3ce, 0xc007633bf0?})
	/app/scrapers/kubernetes/kubernetes.go:400 +0x3928
github.com/flanksource/config-db/scrapers/kubernetes.KubernetesScraper.Scrape({}, {{{{0xaa1e5f0, 0xc02b1aaba0}, {0xaa54510, 0xc007633bf0}, 0x9cb51d8, 0x9cb51e0, {0xa9e8a30, 0xc000f459a0}}}, 0xc01787cf90, ...})
	/app/scrapers/kubernetes/kubernetes.go:151 +0x275
github.com/flanksource/config-db/scrapers.Run({{{{0xaa1e5f0, 0xc02b1aaba0}, {0xaa54510, 0xc007633bf0}, 0x9cb51d8, 0x9cb51e0, {0xa9e8a30, 0xc000f459a0}}}, 0xc01787cf90, {0x0, ...}, ...})
	/app/scrapers/runscrapers.go:54 +0x203
github.com/flanksource/config-db/scrapers.RunScraper({{{{0xaa1e5f0, 0xc02b1aaba0}, {0xaa54510, 0xc007633bf0}, 0x9cb51d8, 0x9cb51e0, {0xa9e8a30, 0xc000f459a0}}}, 0xc01787cf90, {0x0, ...}, ...})
	/app/scrapers/run.go:34 +0x578
github.com/flanksource/config-db/scrapers.newScraperJob.func1({{{{0xaa1e5f0, 0xc020d29e90}, {0xaa54510, 0xc0074ffd70}, 0x9cb51d8, 0x9cb51e0, {0xa9e8a30, 0xc000f459a0}}}, 0xc001458840, {0xaa3a8f0, ...}, ...})
	/app/scrapers/cron.go:208 +0x99
github.com/flanksource/duty/job.(*Job).Run(0xc001458840)
	/go/pkg/mod/github.com/flanksource/duty@v1.0.588/job/job.go:367 +0xf5d
github.com/flanksource/duty/job.(*Job).AddToScheduler.func1()
	/go/pkg/mod/github.com/flanksource/duty@v1.0.588/job/job.go:563 +0x158
github.com/robfig/cron/v3.FuncJob.Run(0xc0016257d0?)
	/go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:136 +0x12
github.com/robfig/cron/v3.(*Cron).startJob.func1()
	/go/pkg/mod/github.com/robfig/cron/v3@v3.0.1/cron.go:312 +0x5b
```