### PR TITLE
feat: customizable certificate expiry warning period

### DIFF
--- a/pkg/health/health_cert_manager.go
+++ b/pkg/health/health_cert_manager.go
@@ -7,6 +7,14 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
+var (
+	defaultCertExpiryWarningPeriod = time.Hour * 24 * 2
+)
+
+func SetDefaultCertificateExpiryWarningPeriod(p time.Duration) {
+	defaultCertExpiryWarningPeriod = p
+}
+
 func GetCertificateHealth(obj *unstructured.Unstructured) (*HealthStatus, error) {
 	if _renewalTime, ok := obj.Object["status"].(map[string]any)["renewalTime"]; ok {
 		if renewalTimeString := _renewalTime.(string); ok {
@@ -33,7 +41,7 @@ func GetCertificateHealth(obj *unstructured.Unstructured) (*HealthStatus, error)
 				return nil, fmt.Errorf("failed to parse notAfter time(%s): %v", notAfter, err)
 			}
 
-			if time.Until(notAfterTime) < time.Hour {
+			if time.Until(notAfterTime) < defaultCertExpiryWarningPeriod {
 				return &HealthStatus{
 					Health:  HealthWarning,
 					Status:  HealthStatusWarning,

--- a/pkg/health/health_test.go
+++ b/pkg/health/health_test.go
@@ -84,7 +84,12 @@ func TestNamespace(t *testing.T) {
 }
 
 func TestCertificate(t *testing.T) {
-	assertAppHealth(t, "./testdata/about-to-expire.yaml", "Warning", health.HealthWarning, true)
+	assertAppHealth(t, "./testdata/certificate-expired.yaml", "Expired", health.HealthUnhealthy, true)
+
+	assertAppHealthWithOverwrite(t, "./testdata/about-to-expire.yaml", map[string]string{
+		"2024-06-26T12:25:46Z": time.Now().Add(time.Hour).UTC().Format("2006-01-02T15:04:05Z"),
+	}, health.HealthStatusWarning, health.HealthWarning, true)
+
 	assertAppHealth(t, "./testdata/certificate-healthy.yaml", "Issued", health.HealthHealthy, true)
 	b := "../resource_customizations/cert-manager.io/Certificate/testdata/"
 	assertAppHealth(t, b+"degraded_configError.yaml", "ConfigError", health.HealthUnhealthy, true)

--- a/pkg/health/testdata/certificate-expired.yaml
+++ b/pkg/health/testdata/certificate-expired.yaml
@@ -1,0 +1,33 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: "2023-12-01T10:15:32Z"
+  generation: 1
+  labels:
+    kustomize.toolkit.fluxcd.io/name: nginx
+    kustomize.toolkit.fluxcd.io/namespace: flux-system
+  name: expired-homelab-cert
+  namespace: nginx-ingress
+  resourceVersion: "32456789"
+  uid: 9e45b2c8-156d-42a1-bc34-7d592f3a1e4d
+spec:
+  commonName: home.flanksource.com
+  dnsNames:
+    - home.flanksource.com
+    - "*.home.flanksource.com"
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-production
+  secretName: expired-homelab-cert
+status:
+  conditions:
+    - lastTransitionTime: "2024-01-01T10:15:38Z"
+      message: Certificate has expired
+      observedGeneration: 1
+      reason: Expired
+      status: "False"
+      type: Ready
+  notAfter: "2024-01-01T10:15:37Z"
+  notBefore: "2023-12-01T10:15:38Z"
+  renewalTime: "2024-01-01T10:15:37Z"
+  revision: 1


### PR DESCRIPTION
since we do not pass in the context on resource health getters, we have to update the global defaults from commons when the property is loaded.