### PR TITLE
fix: rollout failed as unhealthy

### DIFF
--- a/pkg/health/health_deployment.go
+++ b/pkg/health/health_deployment.go
@@ -92,6 +92,9 @@ func getReplicaHealth(s ReplicaStatus) *HealthStatus {
 		}
 	} else if s.Ready == 0 && isStarting {
 		hs.Status = HealthStatusStarting
+		if isProgressDeadlineExceeded {
+			hs.Health = HealthUnhealthy
+		}
 	} else if s.Ready == 0 {
 		hs.Status = lo.Ternary(isAvailable, HealthStatusUpdating, HealthStatusCrashLoopBackoff)
 	}

--- a/pkg/health/health_fixtures_test.go
+++ b/pkg/health/health_fixtures_test.go
@@ -11,12 +11,13 @@ func TestFixtures(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if len(files) == 0 {
 		t.Fatal("no test files found")
 	}
 
 	for _, file := range files {
-		// if file != "testdata/Kubernetes/MissionControl/canary-unhealthy.yaml" {
+		// if file != "testdata/Kubernetes/Deployment/progress-deadline-exceeded.yaml" {
 		// 	continue
 		// }
 

--- a/pkg/health/testdata/Kubernetes/Deployment/progress-deadline-exceeded.yaml
+++ b/pkg/health/testdata/Kubernetes/Deployment/progress-deadline-exceeded.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+    expected-status: Rollout Failed
+    expected-ready: "false"
+    expected-health: "unhealthy"
+    expected-message: 0/1 ready
+  creationTimestamp: "2025-04-11T05:11:25Z"
+  generation: 1
+  labels:
+    app: bad-image-app
+    env: dev
+    region: us-west-1
+  name: bad-image-deployment
+  namespace: mission-control
+  resourceVersion: "473737509"
+  uid: 84541e0f-a6f2-48bf-894e-d9ea656c178a
+spec:
+  progressDeadlineSeconds: 20
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: bad-image-app
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: bad-image-app
+    spec:
+      containers:
+      - image: ngnix:latest
+        imagePullPolicy: Always
+        name: nginx
+        ports:
+        - containerPort: 80
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 500m
+            memory: 512Mi
+          requests:
+            cpu: 200m
+            memory: 256Mi
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  conditions:
+  - lastTransitionTime: "2025-04-11T05:11:25Z"
+    lastUpdateTime: "2025-04-11T05:11:25Z"
+    message: Deployment does not have minimum availability.
+    reason: MinimumReplicasUnavailable
+    status: "False"
+    type: Available
+  - lastTransitionTime: "2025-04-11T05:11:46Z"
+    lastUpdateTime: "2025-04-11T05:11:46Z"
+    message: ReplicaSet "bad-image-deployment-657df9457" has timed out progressing.
+    reason: ProgressDeadlineExceeded
+    status: "False"
+    type: Progressing
+  observedGeneration: 1
+  replicas: 1
+  unavailableReplicas: 1
+  updatedReplicas: 1


### PR DESCRIPTION
Mark deployments as `unhealthy` when no pods are ready and the progress deadline has been exceeded, instead of reporting a `warning`.